### PR TITLE
Add exponential backoff retry to transaction retry decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+Unreleased
+----------
+
+* Added arguments `retries` and `backoff_factor` to `retry_transaction` decorator.
 
 Version 1.4.0
 -------------
@@ -29,7 +33,7 @@ Released 2018-03-15
   (fixes #25)
 * Change default behaviour of context manager so sessions are closed
   on worker teardown rather than context manager exit (closes #24)
-  
+
 Version 1.1.0
 -------------
 
@@ -68,7 +72,7 @@ Version 0.0.3
 Released 2016-08-26
 
 * Added `pytest` fixtures for managing session in tests.
- 
+
 Version 0.0.2
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Release Notes
 Unreleased
 ----------
 
-* Added arguments `retries` and `backoff_factor` to `retry_transaction` decorator.
+* Add retry arguments to `retry_transaction` decorator.
 
 Version 1.4.0
 -------------

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,18 @@ or using with the ``Database`` dependency provider
             self.db.session.add(ExampleModel(data='hello'))
             self.db.session.commit()
 
+Optionally,the transaction may be retried multiple times with an exponential backoff delay.
+In the following code, the session will be retried after 0, 1, 2 and 4 seconds, finally raising the error if the connection still has not recovered.
+
+.. code-block:: python
+
+    @transaction_retry(retries=4, backoff_factor=1)
+    def get_example_data():
+        db_session.query(ExampleModel).all()
+
+    example_data = get_example_data()
+
+
 .. caution::
 
     Using the decorator may cause unanticipated consequences when the decorated function uses more than one transaction.
@@ -320,4 +332,3 @@ If ``toxiproxy-api-url`` and ``toxiproxy-db-url`` parameters are provided the te
         --toxiproxy-db-url="http://toxiproxy_server:3306"
 
 if no ``toxiproxy-api-url`` and ``toxiproxy-db-url`` parameter was provided the tests that require toxiproxy will be skipped.
-

--- a/README.rst
+++ b/README.rst
@@ -171,11 +171,14 @@ or using with the ``Database`` dependency provider
             self.db.session.commit()
 
 Optionally,the transaction may be retried multiple times with an exponential backoff delay.
-In the following code, the session will be retried after 0, 1, 2 and 4 seconds, finally raising the error if the connection still has not recovered.
+
+In the following code, the session will be retried after 1, 3, 9, 10, and 10 seconds:
+The initial delay is given by the `delay` argument. On subsequent retries, the delay is multiplied by the factor provided by `backoff` but will never exceed the delay given in `max_delay`.
+Finally, if the connection has still not recovered after `max_attempts` tries, the error is reraised.
 
 .. code-block:: python
 
-    @transaction_retry(retries=4, backoff_factor=1)
+    @transaction_retry(max_attempts=5, delay=1, backoff=3, max_delay=10)
     def get_example_data():
         db_session.query(ExampleModel).all()
 

--- a/nameko_sqlalchemy/transaction_retry.py
+++ b/nameko_sqlalchemy/transaction_retry.py
@@ -1,24 +1,25 @@
+from time import sleep
 import functools
 import operator
 
 import wrapt
 from sqlalchemy import exc
-from nameko.utils.retry import retry
 
 
-def transaction_retry(wrapped=None, session=None,
-                      max_attempts=1, delay=0, backoff=1, max_delay=None):
+def transaction_retry(wrapped=None, session=None, total=1,
+                      backoff_factor=0, backoff_max=None):
 
     if wrapped is None:
         return functools.partial(
-            transaction_retry, session=session, max_attempts=max_attempts,
-            delay=delay, backoff=backoff, max_delay=max_delay)
+            transaction_retry, session=session,
+            total=total,
+            backoff_factor=backoff_factor,
+            backoff_max=backoff_max)
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
 
-        @retry(for_exceptions=exc.OperationalError, max_attempts=max_attempts,
-               delay=delay, backoff=backoff, max_delay=max_delay)
+        @retry(total, backoff_factor, backoff_max, exc.OperationalError)
         def run_or_rollback():
             try:
                 return wrapped(*args, **kwargs)
@@ -33,3 +34,32 @@ def transaction_retry(wrapped=None, session=None,
         return run_or_rollback()
 
     return wrapper(wrapped)  # pylint: disable=E1120
+
+
+def retry(total, backoff_factor, backoff_max, exceptions):
+
+    total = max(total, 1)
+    backoff_factor = max(backoff_factor, 0)
+    backoff_max = float('inf') if backoff_max is None else max(0, backoff_max)
+
+    @wrapt.decorator
+    def wrapper(wrapped, instance, args, kwargs):
+        errors = 0
+        while True:
+            try:
+                return wrapped(*args, **kwargs)
+            except exceptions:
+                errors += 1
+
+                if errors > total:
+                    raise
+
+                if errors >= 2:
+                    backoff_value = backoff_factor * (2 ** (errors - 1))
+                else:
+                    backoff_value = 0
+                backoff_value = min(backoff_value, backoff_max)
+
+                sleep(backoff_value)
+
+    return wrapper

--- a/nameko_sqlalchemy/transaction_retry.py
+++ b/nameko_sqlalchemy/transaction_retry.py
@@ -1,23 +1,24 @@
-
-import eventlet
 import functools
 import operator
 
 import wrapt
 from sqlalchemy import exc
+from nameko.utils.retry import retry
 
 
-def transaction_retry(wrapped=None, session=None, retries=1, backoff_factor=0):
+def transaction_retry(wrapped=None, session=None,
+                      max_attempts=1, delay=0, backoff=1, max_delay=None):
 
     if wrapped is None:
         return functools.partial(
-            transaction_retry, session=session,
-            retries=retries, backoff_factor=backoff_factor)
+            transaction_retry, session=session, max_attempts=max_attempts,
+            delay=delay, backoff=backoff, max_delay=max_delay)
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
 
-        @retry(retries, backoff_factor, exc.OperationalError)
+        @retry(for_exceptions=exc.OperationalError, max_attempts=max_attempts,
+               delay=delay, backoff=backoff, max_delay=max_delay)
         def run_or_rollback():
             try:
                 return wrapped(*args, **kwargs)
@@ -32,30 +33,3 @@ def transaction_retry(wrapped=None, session=None, retries=1, backoff_factor=0):
         return run_or_rollback()
 
     return wrapper(wrapped)  # pylint: disable=E1120
-
-
-def retry(retries, backoff_factor, exceptions):
-
-    retries = max(retries, 1)
-    backoff_factor = max(backoff_factor, 0)
-
-    @wrapt.decorator
-    def wrapper(wrapped, instance, args, kwargs):
-        errors = 0
-        while True:
-            try:
-                return wrapped(*args, **kwargs)
-            except exceptions:
-                errors += 1
-
-                if errors > retries:
-                    raise
-
-                if errors >= 2:
-                    backoff_value = backoff_factor * (2 ** (errors - 2))
-                else:
-                    backoff_value = 0
-
-                eventlet.sleep(backoff_value)
-
-    return wrapper

--- a/nameko_sqlalchemy/transaction_retry.py
+++ b/nameko_sqlalchemy/transaction_retry.py
@@ -1,3 +1,5 @@
+
+import eventlet
 import functools
 import operator
 
@@ -5,24 +7,55 @@ import wrapt
 from sqlalchemy import exc
 
 
-def transaction_retry(wrapped=None, session=None):
+def transaction_retry(wrapped=None, session=None, retries=1, backoff_factor=0):
 
     if wrapped is None:
-        return functools.partial(transaction_retry, session=session)
+        return functools.partial(
+            transaction_retry, session=session,
+            retries=retries, backoff_factor=backoff_factor)
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
 
-        try:
-            return wrapped(*args, **kwargs)
-        except exc.OperationalError as exception:
-            if exception.connection_invalidated:
-                if isinstance(session, operator.attrgetter):
-                    session(instance).rollback()
-                elif session:
-                    session.rollback()
+        @retry(retries, backoff_factor, exc.OperationalError)
+        def run_or_rollback():
+            try:
                 return wrapped(*args, **kwargs)
-            else:
+            except exc.OperationalError as exception:
+                if exception.connection_invalidated:
+                    if isinstance(session, operator.attrgetter):
+                        session(instance).rollback()
+                    elif session:
+                        session.rollback()
                 raise
 
+        return run_or_rollback()
+
     return wrapper(wrapped)  # pylint: disable=E1120
+
+
+def retry(retries, backoff_factor, exceptions):
+
+    retries = max(retries, 1)
+    backoff_factor = max(backoff_factor, 0)
+
+    @wrapt.decorator
+    def wrapper(wrapped, instance, args, kwargs):
+        errors = 0
+        while True:
+            try:
+                return wrapped(*args, **kwargs)
+            except exceptions:
+                errors += 1
+
+                if errors > retries:
+                    raise
+
+                if errors >= 2:
+                    backoff_value = backoff_factor * (2 ** (errors - 2))
+                else:
+                    backoff_value = 0
+
+                eventlet.sleep(backoff_value)
+
+    return wrapper

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'dev': [
             "coverage==4.0.3",
             "flake8==2.5.4",
-            "pylint==1.7.5",
+            "pylint==1.9.4",
             "pytest==2.9.1",
             "requests==2.18.4",
             "PyMySQL",


### PR DESCRIPTION
* Adds arguments `retries` and `backoff_factor` to retry_transaction decorator
* Default behavior stays the same
* Closes #22 