### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 
 services:
   - docker
-  - mysql
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python: 3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+python: 3.7
+
+dist: xenial
 
 services:
   - docker
@@ -21,6 +24,9 @@ matrix:
     - stage: test
       python: 3.6
       env: TOX_ENV=py36
+    - stage: test
+      python: 3.7
+      env: TOX_ENV=py37
     - stage: deploy
       script: skip
       deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test: flake8 pylint pytest
 
 flake8:
-	flake8 nameko_sqlalchemy test
+	flake8 nameko_sqlalchemy test setup.py
 
 pylint:
 	pylint nameko_sqlalchemy -E

--- a/README.rst
+++ b/README.rst
@@ -295,8 +295,8 @@ By default SQLite memory database will be used.
 
 .. code-block:: shell
 
-    py.test test --test-db-url=sqlite:///test_db.sql
-    py.test test --test-db-url=mysql+mysqlconnector://root:password@localhost:3306/nameko_sqlalchemy_test
+    pytest test --test-db-url=sqlite:///test_db.sql
+    pytest test --test-db-url=mysql+mysqlconnector://root:password@localhost:3306/nameko_sqlalchemy_test
 
 
 Running the tests
@@ -323,10 +323,10 @@ Once the containers have been set up the tests can be run by running the followi
     make test
 
 
-Running tests by using py.test command
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Running tests by using pytest command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Three extra parameters may be passed to `py.test`:
+Three extra parameters may be passed to `pytest`:
 
 * ``test-db-url``: The database URL
 * ``toxiproxy-api-url``: The url of the Toxiproxy HTTP API
@@ -336,7 +336,7 @@ If ``toxiproxy-api-url`` and ``toxiproxy-db-url`` parameters are provided the te
 
 .. code-block:: shell
 
-    py.test test \
+    pytest test \
         --test-db-url="mysql+pymysql://test_user:password@database_host:3306/nameko_sqlalchemy_test" \
         --toxiproxy-api-url="http://toxiproxy_server:8474"
         --toxiproxy-db-url="http://toxiproxy_server:3306"

--- a/nameko_sqlalchemy/database_session.py
+++ b/nameko_sqlalchemy/database_session.py
@@ -47,5 +47,6 @@ class DatabaseSession(DependencyProvider):
         session = self.sessions.pop(worker_ctx)
         session.close()
 
+
 # backwards compat
 Session = DatabaseSession

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ setup(
     ],
     extras_require={
         'dev': [
-            "coverage==4.0.3",
-            "flake8==2.5.4",
-            "pylint==1.9.4",
-            "pytest==2.9.1",
-            "requests==2.18.4",
+            "coverage==4.5.3",
+            "flake8==3.7.7",
+            "pylint>=1.9.4",  # pinned for py27 support
+            "pytest==4.3.1",
+            "requests==2.21.0",
             "PyMySQL",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -31,17 +31,20 @@ setup(
     zip_safe=True,
     license='Apache License, Version 2.0',
     classifiers=[
-        "Programming Language :: Python",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Intended Audience :: Developers",
+
     ]
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,7 +8,6 @@ eventlet.monkey_patch()  # noqa (code before rest of imports)
 
 import pytest
 import requests
-from nameko.containers import ServiceContainer
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -23,25 +22,6 @@ class ExampleModel(DeclarativeBase):
     __tablename__ = 'example'
     id = Column(Integer, primary_key=True)
     data = Column(String(100))
-
-
-@pytest.yield_fixture
-def container_factory():
-
-    all_containers = []
-
-    def make_container(service_cls, config):
-        container = ServiceContainer(service_cls, config)
-        all_containers.append(container)
-        return container
-
-    yield make_container
-
-    for c in all_containers:
-        try:
-            c.stop()
-        except:  # noqa: E722
-            pass
 
 
 @pytest.yield_fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,7 +40,7 @@ def container_factory():
     for c in all_containers:
         try:
             c.stop()
-        except:
+        except:  # noqa: E722
             pass
 
 

--- a/test/test_pytest_fixtures.py
+++ b/test/test_pytest_fixtures.py
@@ -67,7 +67,7 @@ class TestDbEngineOptions(object):
             import pytest
             from mock import Mock, patch
 
-            @pytest.yield_fixture
+            @pytest.fixture(scope='session')
             def create_engine_mock():
                 with patch(
                     'nameko_sqlalchemy.pytest_fixtures.create_engine'
@@ -94,7 +94,7 @@ class TestDbEngineOptions(object):
             import pytest
             from mock import Mock, patch
 
-            @pytest.yield_fixture
+            @pytest.fixture(scope='session')
             def create_engine_mock():
                 with patch(
                     'nameko_sqlalchemy.pytest_fixtures.create_engine'

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,18 @@
 [tox]
-envlist = {py27,py34,py35,py36}-test
+envlist = {py27,py34,py35,py36}
 skipsdist = True
 
 [testenv]
 whitelist_externals = make
 
+usedevelop = true
+extras =
+    dev
+
 deps =
     # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
     # in https://github.com/eventlet/eventlet/issues/401 is released
     py27: eventlet==0.20.1
-    py27-examples: eventlet==0.20.1
 
 commands =
-    pip install --editable .[dev]
     make test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}
+envlist = {py27,py34,py35,py36,py37}
 skipsdist = True
 
 [testenv]
@@ -11,7 +11,7 @@ extras =
 
 deps =
     py27: pylint==1.9.4
-    py{34,35,36}: pylint==2.3.1
+    py{34,35,36,37}: pylint==2.3.1
 
 commands =
     make test

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,8 @@ extras =
     dev
 
 deps =
-    # we can't test eventlet>0.20.1 in our py27 CI environment until the fix
-    # in https://github.com/eventlet/eventlet/issues/401 is released
-    py27: eventlet==0.20.1
+    py27: pylint==1.9.4
+    py{34,35,36}: pylint==2.3.1
 
 commands =
     make test


### PR DESCRIPTION
Preparing the library for Python 3.7.
After updating the `dev` requirements, it seems to work fine and all the tests pass successfully.

* Add Python 3.7 support:
  * Use Ubuntu `xenial`
  * `sudo` Travis keyword has been fully deprecated
* Upgrade `dev` requirements to the latest version:
  * Remove pinned versions that are no longer necessary
  * Pin `pylint` for Python 2
  * Fix `pep8` after upgrading `flake8`
  * Fix tests after upgrading `pytest`
* Improve Tox configuration: develop mode, install `dev` extras, remove unused code.
* Remove unused `mysql` Travis service since we're user Docker containers
* Update `pytest` references in the documentation